### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     },
     "license": "MIT",
     "require": {
-        "php": "^7.0",
-        "traderinteractive/exceptions": "^1.0"
+        "php": "^7.3 || ^8.0",
+        "traderinteractive/exceptions": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/tests/Filter/IntsTest.php
+++ b/tests/Filter/IntsTest.php
@@ -73,33 +73,33 @@ final class IntsTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage "true" $value is not a string
      */
     public function filterNonStringOrInt()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('"true" $value is not a string');
         Ints::filter(true);
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value string length is zero
      */
     public function filterEmptyString()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value string length is zero');
         Ints::filter('');
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value string length is zero
      */
     public function filterWhitespaceString()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value string length is zero');
         Ints::filter('   ');
     }
 
@@ -124,10 +124,10 @@ final class IntsTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
      */
     public function filterGreaterThanPhpIntMax()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
         //32, 64 and 128 bit and their +1 's
         $maxes = [
             '2147483647' => '2147483648',
@@ -141,10 +141,10 @@ final class IntsTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
      */
     public function filterLessThanPhpIntMin()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
         //32, 64 and 128 bit and their -1 's
         $mins = [
             '-2147483648' => '-2147483649',
@@ -158,11 +158,11 @@ final class IntsTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage -1 is less than 0
      */
     public function filterLessThanMin()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('-1 is less than 0');
         Ints::filter(-1, false, 0);
     }
 
@@ -178,11 +178,11 @@ final class IntsTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage 1 is greater than 0
      */
     public function filterGreaterThanMax()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('1 is greater than 0');
         Ints::filter(1, false, null, 0);
     }
 

--- a/tests/Filter/UnsignedIntTest.php
+++ b/tests/Filter/UnsignedIntTest.php
@@ -13,11 +13,11 @@ final class UnsignedIntTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage -1 was not greater or equal to zero
      */
     public function filterMinValueNegative()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('-1 was not greater or equal to zero');
         UnsignedInt::filter('1', false, -1);
     }
 
@@ -33,11 +33,11 @@ final class UnsignedIntTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage -1 is less than 0
      */
     public function filterMinValueDefaultFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('-1 is less than 0');
         UnsignedInt::filter('-1', false);
     }
 
@@ -62,33 +62,33 @@ final class UnsignedIntTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value failed filtering, $allowNull is set to false
      */
     public function filterAllowNullFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('Value failed filtering, $allowNull is set to false');
         UnsignedInt::filter(null, false);
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage 0 is less than 1
      */
     public function filterMinValueFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('0 is less than 1');
         $this->assertSame(1, UnsignedInt::filter('0', false, 1));
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage 2 is greater than 1
      */
     public function filterMaxValueFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('2 is greater than 1');
         UnsignedInt::filter('2', false, 0, 1);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Backwards breaking; Remove Support for PHP 7.2 and earlier.
Upgrade to PHPUnit 9.

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

